### PR TITLE
add phpsp + pub

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ## 2023
 
-| Data | Evento | Modalidade | Link | Cidade - UF |
-| --- | --- | --- | --- | --- |
-| 19/01 | Beer.php MG           | Presencial | [Meetup Beer.php](https://www.meetup.com/pt-BR/php-mg/events/290922553) | Belo Horizonte - MG |
-| 04/02 | MeetuPHP com Rapadura | Presencial | [MeetuPHP com Rapadura](http://meetup.phpcomrapadura.org/) | Fortaleza - CE |
-
+| Data                             | Evento                | Modalidade | Link                                                                    | Cidade - UF         |
+| -------------------------------- | --------------------- | ---------- | ----------------------------------------------------------------------- | ------------------- |
+| 19/01                            | Beer.php MG           | Presencial | [Meetup Beer.php](https://www.meetup.com/pt-BR/php-mg/events/290922553) | Belo Horizonte - MG |
+| 04/02                            | MeetuPHP com Rapadura | Presencial | [MeetuPHP com Rapadura](http://meetup.phpcomrapadura.org/)              | Fortaleza - CE      |
+| Toda segunda Quinta-feira do mês | PHPSP + Pub           | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/)             | São Paulo - SP      |

--- a/README.md
+++ b/README.md
@@ -2,8 +2,18 @@
 
 ## 2023
 
-| Data                             | Evento                | Modalidade | Link                                                                    | Cidade - UF         |
-| -------------------------------- | --------------------- | ---------- | ----------------------------------------------------------------------- | ------------------- |
-| 19/01                            | Beer.php MG           | Presencial | [Meetup Beer.php](https://www.meetup.com/pt-BR/php-mg/events/290922553) | Belo Horizonte - MG |
-| 04/02                            | MeetuPHP com Rapadura | Presencial | [MeetuPHP com Rapadura](http://meetup.phpcomrapadura.org/)              | Fortaleza - CE      |
-| Toda segunda Quinta-feira do mês | PHPSP + Pub           | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/)             | São Paulo - SP      |
+| Data | Evento | Modalidade | Link | Cidade - UF |
+| --- | --- | --- | --- | --- |
+| 19/01 | Beer.php MG           | Presencial | [Meetup Beer.php](https://www.meetup.com/pt-BR/php-mg/events/290922553) | Belo Horizonte - MG |
+| 04/02 | MeetuPHP com Rapadura | Presencial | [MeetuPHP com Rapadura](http://meetup.phpcomrapadura.org/) | Fortaleza - CE |
+| 09/02 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
+| 09/03 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
+| 13/04 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
+| 11/05 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
+| 08/06 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
+| 13/07 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
+| 10/08 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
+| 14/09 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
+| 12/10 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
+| 09/11 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
+| 14/12 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |


### PR DESCRIPTION
# Adição de evento

## Descrição do evento

Que tal reunir PHP, bebida gelada e comida boa em um só lugar?
O PHPSP Pub é o evento mais antigo da comunidade e acontece há mais de 7 anos, sempre na segunda quinta-feira do mês com a proposta de reunir a descontração de um pub e o conhecimento da comunidade.

A gente bota cerveja (não alcoólica também vale), opinião e muito conhecimento na mesma roda de discussão. Agile, DevOps, mercado de TI, novidades, respeito ao próximo e obviamente muito PHP são postos para discussão, para todo mundo interagir, tirar dúvidas e espalhar conhecimento.
