### PR TITLE
Adicionado eventos do PHPMG

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@
 | 09/02 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
 | 10/02 | BotecoPHP | Presencial | [Meetup PHP Rio](https://www.meetup.com/pt-BR/php-rio/events/291469592) | Rio de Janeiro - RJ |
 | 13/02 | PHPMG Podcast | Online | [PHPMG Live](https://youtube.com/live/b3I-WoVKKNM?feature=share) | Belo Horizonte - MG |
+| 01/03 | 23º PHPMG Talks - PSR, HyperF e comunidades | Presencial | [Meetup PHPMG Talks](https://www.meetup.com/pt-BR/php-mg/events/291592989/) | Belo Horizonte - MG |
 | 03/03 | Meetup PHP Rio | Presencial | [Meetup PHP Rio](https://www.meetup.com/pt-BR/php-rio/events/291315790) | Rio de Janeiro - RJ |
 | 09/03 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
+| 16/03 | Beer.php MG | Presencial | [Meetup Beer.php](https://www.meetup.com/pt-BR/php-mg/events/291593663) | Belo Horizonte - MG |
 | 13/04 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
 | 11/05 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
 | 08/06 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |


### PR DESCRIPTION
# Adição de evento

## Descrição do evento

Foi adicionado a lista de eventos o tradicional meetup do PHPMG e o beer.php, o meetup tem como foco principal trazer conteúdo relacionado a tecnologia, mercado e carreira para a comunidade de PHP de MG, já o beer é um encontro para descontrair com a galera da comunidade

Adicione aqui uma descrição do evento, explicando seu propósito, público alvo e quaisquer outras informações pertinentes

## Organizadores

Diego Borges Ferreira - https://www.linkedin.com/in/eudiegoborgs/
