### PR TITLE
Add PHP Velho Oeste - 29/07

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 | 11/05 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
 | 08/06 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
 | 13/07 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
+| 29/07 | 1º PHP Velho Oeste | Presencial | [PHP Velho Oeste](http://phpvelhoeste.com.br/) | Chapecó - SC |
 | 10/08 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
 | 14/09 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
 | 06/10 | PHPeste | Presencial | [PHPeste 2023](https://www.phpeste.org/) | Fortaleza - CE |

--- a/README.md
+++ b/README.md
@@ -2,27 +2,26 @@
 
 ## 2023
 
-| Data  | Evento                                      | Modalidade | Link                                                                        | Cidade - UF         |
-|-------|---------------------------------------------| --- |-----------------------------------------------------------------------------|---------------------|
-| 19/01 | Beer.php MG                                 | Presencial | [Meetup Beer.php](https://www.meetup.com/pt-BR/php-mg/events/290922553)     | Belo Horizonte - MG |
-| 27/01 | Meetup PHP Rio                              | Presencial | [Meetup PHP Rio](https://www.meetup.com/pt-BR/php-rio/events/290767139/)    | Rio de Janeiro - RJ |
-| 04/02 | MeetuPHP com Rapadura                       | Presencial | [MeetuPHP com Rapadura](http://meetup.phpcomrapadura.org/)                  | Fortaleza - CE      |
-| 09/02 | PHPSP + Pub                                 | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/)                 | São Paulo - SP      |
-| 10/02 | BotecoPHP                                   | Presencial | [Meetup PHP Rio](https://www.meetup.com/pt-BR/php-rio/events/291469592)     | Rio de Janeiro - RJ |
-| 13/02 | PHPMG Podcast                               | Online | [PHPMG Live](https://youtube.com/live/b3I-WoVKKNM?feature=share)            |                     |
+| Data | Evento | Modalidade | Link | Cidade - UF |
+| --- | --- | --- | --- | --- |
+| 19/01 | Beer.php MG | Presencial | [Meetup Beer.php](https://www.meetup.com/pt-BR/php-mg/events/290922553) | Belo Horizonte - MG |
+| 27/01 | Meetup PHP Rio | Presencial | [Meetup PHP Rio](https://www.meetup.com/pt-BR/php-rio/events/290767139/) | Rio de Janeiro - RJ |
+| 04/02 | MeetuPHP com Rapadura | Presencial | [MeetuPHP com Rapadura](http://meetup.phpcomrapadura.org/) | Fortaleza - CE |
+| 09/02 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
+| 10/02 | BotecoPHP | Presencial | [Meetup PHP Rio](https://www.meetup.com/pt-BR/php-rio/events/291469592) | Rio de Janeiro - RJ |
+| 13/02 | PHPMG Podcast | Online | [PHPMG Live](https://youtube.com/live/b3I-WoVKKNM?feature=share) |  |
 | 01/03 | 23º PHPMG Talks - PSR, HyperF e comunidades | Presencial | [Meetup PHPMG Talks](https://www.meetup.com/pt-BR/php-mg/events/291592989/) | Belo Horizonte - MG |
-| 03/03 | Meetup PHP Rio                              | Presencial | [Meetup PHP Rio](https://www.meetup.com/pt-BR/php-rio/events/291315790)     | Rio de Janeiro - RJ |
-| 08/03 | PHPinga                                     | Presencial | [Eventos do PHP com Rapadura](https://phpcomrapadura.org/eventos)           | Fortaleza - CE      |
-| 09/03 | PHPSP + Pub                                 | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/)                 | São Paulo - SP      |
-| 16/03 | Beer.php MG                                 | Presencial | [Meetup Beer.php](https://www.meetup.com/pt-BR/php-mg/events/291593663)     | Belo Horizonte - MG |
-| 13/04 | PHPSP + Pub                                 | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/)                 | São Paulo - SP      |
-| 11/05 | PHPSP + Pub                                 | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/)                 | São Paulo - SP      |
-| 08/06 | PHPSP + Pub                                 | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/)                 | São Paulo - SP      |
-| 13/07 | PHPSP + Pub                                 | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/)                 | São Paulo - SP      |
-| 29/07 | 1ª PHP Velho Oeste                          | Presencial | [PHP Velho Oeste](http://phpvelhoeste.com.br/)                              | Chapecó - SC        |
-| 10/08 | PHPSP + Pub                                 | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/)                 | São Paulo - SP      |
-| 14/09 | PHPSP + Pub                                 | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/)                 | São Paulo - SP      |
-| 06/10 | PHPeste                                     | Presencial | [PHPeste 2023](https://www.phpeste.org/)                                    | Fortaleza - CE      |
-| 12/10 | PHPSP + Pub                                 | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/)                 | São Paulo - SP      |
-| 09/11 | PHPSP + Pub                                 | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/)                 | São Paulo - SP      |
-| 14/12 | PHPSP + Pub                                 | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/)                 | São Paulo - SP      |
+| 03/03 | Meetup PHP Rio | Presencial | [Meetup PHP Rio](https://www.meetup.com/pt-BR/php-rio/events/291315790) | Rio de Janeiro - RJ |
+| 08/03 | PHPinga | Presencial | [Eventos do PHP com Rapadura](https://phpcomrapadura.org/eventos) | Fortaleza - CE |
+| 09/03 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
+| 16/03 | Beer.php MG | Presencial | [Meetup Beer.php](https://www.meetup.com/pt-BR/php-mg/events/291593663) | Belo Horizonte - MG |
+| 13/04 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
+| 11/05 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
+| 08/06 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
+| 13/07 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
+| 10/08 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
+| 14/09 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
+| 06/10 | PHPeste | Presencial | [PHPeste 2023](https://www.phpeste.org/) | Fortaleza - CE |
+| 12/10 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
+| 09/11 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
+| 14/12 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |

--- a/README.md
+++ b/README.md
@@ -2,26 +2,27 @@
 
 ## 2023
 
-| Data | Evento | Modalidade | Link | Cidade - UF |
-| --- | --- | --- | --- | --- |
-| 19/01 | Beer.php MG | Presencial | [Meetup Beer.php](https://www.meetup.com/pt-BR/php-mg/events/290922553) | Belo Horizonte - MG |
-| 27/01 | Meetup PHP Rio | Presencial | [Meetup PHP Rio](https://www.meetup.com/pt-BR/php-rio/events/290767139/) | Rio de Janeiro - RJ |
-| 04/02 | MeetuPHP com Rapadura | Presencial | [MeetuPHP com Rapadura](http://meetup.phpcomrapadura.org/) | Fortaleza - CE |
-| 09/02 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
-| 10/02 | BotecoPHP | Presencial | [Meetup PHP Rio](https://www.meetup.com/pt-BR/php-rio/events/291469592) | Rio de Janeiro - RJ |
-| 13/02 | PHPMG Podcast | Online | [PHPMG Live](https://youtube.com/live/b3I-WoVKKNM?feature=share) |  |
+| Data  | Evento                                      | Modalidade | Link                                                                        | Cidade - UF         |
+|-------|---------------------------------------------| --- |-----------------------------------------------------------------------------|---------------------|
+| 19/01 | Beer.php MG                                 | Presencial | [Meetup Beer.php](https://www.meetup.com/pt-BR/php-mg/events/290922553)     | Belo Horizonte - MG |
+| 27/01 | Meetup PHP Rio                              | Presencial | [Meetup PHP Rio](https://www.meetup.com/pt-BR/php-rio/events/290767139/)    | Rio de Janeiro - RJ |
+| 04/02 | MeetuPHP com Rapadura                       | Presencial | [MeetuPHP com Rapadura](http://meetup.phpcomrapadura.org/)                  | Fortaleza - CE      |
+| 09/02 | PHPSP + Pub                                 | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/)                 | São Paulo - SP      |
+| 10/02 | BotecoPHP                                   | Presencial | [Meetup PHP Rio](https://www.meetup.com/pt-BR/php-rio/events/291469592)     | Rio de Janeiro - RJ |
+| 13/02 | PHPMG Podcast                               | Online | [PHPMG Live](https://youtube.com/live/b3I-WoVKKNM?feature=share)            |                     |
 | 01/03 | 23º PHPMG Talks - PSR, HyperF e comunidades | Presencial | [Meetup PHPMG Talks](https://www.meetup.com/pt-BR/php-mg/events/291592989/) | Belo Horizonte - MG |
-| 03/03 | Meetup PHP Rio | Presencial | [Meetup PHP Rio](https://www.meetup.com/pt-BR/php-rio/events/291315790) | Rio de Janeiro - RJ |
-| 08/03 | PHPinga | Presencial | [Eventos do PHP com Rapadura](https://phpcomrapadura.org/eventos) | Fortaleza - CE |
-| 09/03 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
-| 16/03 | Beer.php MG | Presencial | [Meetup Beer.php](https://www.meetup.com/pt-BR/php-mg/events/291593663) | Belo Horizonte - MG |
-| 13/04 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
-| 11/05 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
-| 08/06 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
-| 13/07 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
-| 10/08 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
-| 14/09 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
-| 06/10 | PHPeste | Presencial | [PHPeste 2023](https://www.phpeste.org/) | Fortaleza - CE |
-| 12/10 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
-| 09/11 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
-| 14/12 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
+| 03/03 | Meetup PHP Rio                              | Presencial | [Meetup PHP Rio](https://www.meetup.com/pt-BR/php-rio/events/291315790)     | Rio de Janeiro - RJ |
+| 08/03 | PHPinga                                     | Presencial | [Eventos do PHP com Rapadura](https://phpcomrapadura.org/eventos)           | Fortaleza - CE      |
+| 09/03 | PHPSP + Pub                                 | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/)                 | São Paulo - SP      |
+| 16/03 | Beer.php MG                                 | Presencial | [Meetup Beer.php](https://www.meetup.com/pt-BR/php-mg/events/291593663)     | Belo Horizonte - MG |
+| 13/04 | PHPSP + Pub                                 | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/)                 | São Paulo - SP      |
+| 11/05 | PHPSP + Pub                                 | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/)                 | São Paulo - SP      |
+| 08/06 | PHPSP + Pub                                 | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/)                 | São Paulo - SP      |
+| 13/07 | PHPSP + Pub                                 | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/)                 | São Paulo - SP      |
+| 29/07 | 1ª PHP Velho Oeste                          | Presencial | [PHP Velho Oeste](http://phpvelhoeste.com.br/)                              | Chapecó - SC        |
+| 10/08 | PHPSP + Pub                                 | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/)                 | São Paulo - SP      |
+| 14/09 | PHPSP + Pub                                 | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/)                 | São Paulo - SP      |
+| 06/10 | PHPeste                                     | Presencial | [PHPeste 2023](https://www.phpeste.org/)                                    | Fortaleza - CE      |
+| 12/10 | PHPSP + Pub                                 | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/)                 | São Paulo - SP      |
+| 09/11 | PHPSP + Pub                                 | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/)                 | São Paulo - SP      |
+| 14/12 | PHPSP + Pub                                 | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/)                 | São Paulo - SP      |


### PR DESCRIPTION
# Adição de evento

## Descrição do evento

PHP Velho Oeste é uma comunidade que tem como objetivo movimentar o ecossistema entorno da Linguagem PHP na região Oeste de Santa Catarina, conhecida como Velho Oeste.

Nossa 1ª Edição acontecerá no auditório do [Pollen Parque Científico e Tecnológico](https://www.linkedin.com/company/pollenparque/) de Chapecó/SC, um de nossos parceiros para realização deste evento.

O evento oferecerá uma excelente oportunidade para networking, onde você poderá conhecer outros profissionais da área, fazer contatos valiosos e compartilhar experiências com colegas que também se interessam pela linguagem PHP.

Site: http://phpvelhoeste.com.br/