### PR TITLE
Adicionando PHP Community Summit

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 | 29/07 | 1º PHP Velho Oeste | Presencial | [PHP Velho Oeste](http://phpvelhoeste.com.br/) | Chapecó - SC |
 | 10/08 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
 | 14/09 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
+| 28/09 e 29/09 | PHP Community Summit | Híbrido | [PHP Community Summit](https://php.locaweb.com.br)<br>[Chamada de palestras](https://bit.ly/cfp-phpcs-2023) | São Paulo - SP |
 | 06/10 | PHPeste | Presencial | [PHPeste 2023](https://www.phpeste.org/) | Fortaleza - CE |
 | 12/10 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
 | 09/11 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |


### PR DESCRIPTION
# Adição de evento

## Descrição do evento

O [PHP Community Summit](https://php.locaweb.com.br/) foi criado para estreitar o relacionamento com as comunidades de desenvolvimento e profissionais da tecnologia e aproximar o público de soluções, tendências e inovações sobre os principais temas relacionados ao ecossistema PHP.

Ele ocorrerá em formato híbrido nos dias 28 e 29 de setembro de 2023, das 09h às 19h. O evento presencial ocorrerá na [sede da Locaweb Company](https://goo.gl/maps/c8FueuA9TJYki48f6), em São Paulo/SP.

## Organizadores

A curadoria do evento é feita pelo PHPSP e pode ser contatada [através deste email](mailto:curadoria-phpsc-2023@phpsp.org.br).