### PR TITLE
Add PHPeste 2025 event details to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,7 @@
 | 07/12 | PHP Conference Brasil | Híbrido | [PHP Conference Brasil](https://phpconference.com.br/) | Pedra Branca - SC |
 | 14/12 | PHPSC PUB | Presencial | [Meetup PHPSC Floripa](https://www.meetup.com/pt-BR/phpsc-floripa/events/) | Florianópolis - SC |
 | 14/12 | PHPSP + Pub | Presencial | [Meetup PHPSP](https://www.meetup.com/pt-BR/php-sp/events/) | São Paulo - SP |
+
+## 2025
+| 03/10 | PHPeste 2025 (O maior evento de PHP do Nordeste) | Presencial | [Site](https://phppiaui.com.br/) | Parnaíba - PI |
+


### PR DESCRIPTION
📅 PHPeste 2025
O maior evento de PHP do Nordeste

O PHPeste é um evento comunitário que reúne desenvolvedores, estudantes e entusiastas da linguagem PHP, promovendo palestras técnicas, networking, inclusão e fortalecimento da comunidade local.
A edição de 2025 será realizada na cidade de Parnaíba, no litoral do Piauí, e promete dois dias de muito conteúdo, integração e diversidade.

Data: 03 e 04 de Outubro de 2025

Local: UESPI – Av. Nossa Sra. de Fátima, s/n – Parnaíba/PI

Modalidade: Presencial

👥 Organizadores
Comunidade PHP Piauí – phppiaui@gmail.com